### PR TITLE
broken link fixed

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -35,6 +35,7 @@ if (length(new.packages) > 0) {
 }
 ```
 
+
 ## Course schedule (download full zip on [the course Github page](https://github.com/doserjef/CASANR23-Spatial-Modeling))
 
 [Full PDF of all course slides](slides/all_slides.pdf)

--- a/index.Rmd
+++ b/index.Rmd
@@ -50,7 +50,7 @@ if (length(new.packages) > 0) {
 * 10:00 - 10:30 Break with snacks and registration
 * 10:30 - 12:00 Scalable Bayesian models for big spatial data [slides](slides/LargeSpatial.pdf)
     * Exercise 3
-      * [Markdown doc](exercises/exercise-3/harvard-Forest.html)
+      * [Markdown doc](exercises/exercise-3/Harvard-Forest.html)
       * Code [zip](exercises/exercise-3.zip) or [tar.gz](exercises/exercise-3.tar.gz)
 * 12:00 - 1:30 Group lunch 
 * 1:30 - 2:00 Advanced computing environments [slides](slides/CompNotes.pdf)

--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@ code span.ot { color: #007020; }
 <ul>
 <li>Exercise 3
 <ul>
-<li><a href="exercises/exercise-3/harvard-Forest.html">Markdown doc</a></li>
+<li><a href="exercises/exercise-3/Harvard-Forest.html">Markdown doc</a></li>
 <li>Code <a href="exercises/exercise-3.zip">zip</a> or <a href="exercises/exercise-3.tar.gz">tar.gz</a></li>
 </ul></li>
 </ul></li>


### PR DESCRIPTION
the "markdown doc" for exercise 3 was broken to a difference in case. This fixes it (although you may have to reset browser cookies to see it)